### PR TITLE
Grid component

### DIFF
--- a/packages/app/public/style.css
+++ b/packages/app/public/style.css
@@ -21,16 +21,6 @@ main {
   padding: 0 4vw;
 }
 
-.video-gallery {
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-}
-
-.video-gallery > * {
-  flex-basis: 15%;
-}
-
 .video-details {
   max-width: 48rem;
 }

--- a/packages/app/src/views/ChannelView/ChannelView.tsx
+++ b/packages/app/src/views/ChannelView/ChannelView.tsx
@@ -1,17 +1,17 @@
-import React from "react";
-import { GenericSection, VideoPreview } from "components";
-import { ChannelHeader } from "../../components/ChannelHeader";
-import { RouteComponentProps, useParams } from "@reach/router";
+import React from "react"
+import { GenericSection, VideoPreview, Grid } from "components"
+import { ChannelHeader } from "../../components/ChannelHeader"
+import { RouteComponentProps, useParams } from "@reach/router"
 
 type ChannelProps = {
-  name: string;
-  isPublic?: boolean;
-  isVerified?: boolean;
-  description?: string;
-  banner?: string;
-  videos?: any[];
-  img: string;
-};
+  name: string
+  isPublic?: boolean
+  isVerified?: boolean
+  description?: string
+  banner?: string
+  videos?: any[]
+  img: string
+}
 
 function ChannelComponent({
   name,
@@ -33,8 +33,9 @@ function ChannelComponent({
         img={img}
       />
       <GenericSection auto title="Videos">
-        <div className="video-gallery">
-          {videos.map((video, idx) => (
+        <Grid
+          minItemWidth="250"
+          items={videos.map((video, idx) => (
             <VideoPreview
               url={`videos/${idx}`}
               channelUrl={`channels/${video.channel}`}
@@ -43,20 +44,20 @@ function ChannelComponent({
               poster={video.poster}
             />
           ))}
-        </div>
+        />
       </GenericSection>
     </>
-  );
+  )
 }
 
 type RouteProps = {
-  videos: any;
-  channels: any;
-} & RouteComponentProps;
+  videos: any
+  channels: any
+} & RouteComponentProps
 
 export default function Channel({ videos, channels }: RouteProps) {
-  let params = useParams();
-  let channelVideos = videos[params.channelName];
-  let channel = channels[params.channelName];
-  return <ChannelComponent {...channel} videos={channelVideos} />;
+  let params = useParams()
+  let channelVideos = videos[params.channelName]
+  let channel = channels[params.channelName]
+  return <ChannelComponent {...channel} videos={channelVideos} />
 }

--- a/packages/app/src/views/ExploreView/ExploreView.tsx
+++ b/packages/app/src/views/ExploreView/ExploreView.tsx
@@ -1,26 +1,27 @@
-import React from "react";
-import { Link, RouteComponentProps } from "@reach/router";
-import { GenericSection, VideoPreview, ChannelSummary } from "components";
+import React from "react"
+import { RouteComponentProps } from "@reach/router"
+import { GenericSection, VideoPreview, ChannelSummary, Grid } from "components"
 
 type ExploreViewProps = {
-  videos: any;
-  channels: any;
-} & RouteComponentProps;
+  videos: any
+  channels: any
+} & RouteComponentProps
 
 export default function ExploreView({
   channels,
   videos,
   path,
 }: ExploreViewProps) {
-  let allVideos = Object.values(videos).flat();
-  let allChannels: any[] = Object.values(channels);
+  let allVideos = Object.values(videos).flat()
+  let allChannels: any[] = Object.values(channels)
 
   return (
     <>
       <GenericSection topDivider title="Latest Videos">
-        <div className="video-gallery">
-          {allVideos.map((video, idx) => {
-            let { img: channelImg } = channels[video.channel] || "";
+        <Grid
+          minItemWidth="250"
+          items={allVideos.map((video, idx) => {
+            let { img: channelImg } = channels[video.channel] || ""
 
             return (
               <VideoPreview
@@ -33,9 +34,9 @@ export default function ExploreView({
                 poster={video.poster}
                 showChannel
               />
-            );
+            )
           })}
-        </div>
+        />
       </GenericSection>
       <GenericSection topDivider title="Latest video channels">
         <div className="channel-gallery">
@@ -53,5 +54,5 @@ export default function ExploreView({
         </div>
       </GenericSection>
     </>
-  );
+  )
 }

--- a/packages/app/src/views/ExploreView/ExploreView.tsx
+++ b/packages/app/src/views/ExploreView/ExploreView.tsx
@@ -22,7 +22,6 @@ export default function ExploreView({
           minItemWidth="250"
           items={allVideos.map((video, idx) => {
             let { img: channelImg } = channels[video.channel] || ""
-
             return (
               <VideoPreview
                 url={`videos/${idx}`}

--- a/packages/components/src/components/Grid/Grid.style.ts
+++ b/packages/components/src/components/Grid/Grid.style.ts
@@ -1,16 +1,16 @@
 import { css } from "@emotion/core"
 
 export type GridStyleProps = {
-  minItemWidth?: string
+  minItemWidth?: string | number
 }
 
 export let makeStyles = ({
-  minItemWidth = "200px"
+  minItemWidth = "200"
 }: GridStyleProps) => {
   return {
     container: css`
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(${minItemWidth}, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(${minItemWidth}px, 1fr));
       gap: 30px;
     `,
     item: css`

--- a/packages/components/src/components/Grid/Grid.style.ts
+++ b/packages/components/src/components/Grid/Grid.style.ts
@@ -1,0 +1,21 @@
+import { css } from "@emotion/core"
+
+export type GridStyleProps = {
+  minItemWidth?: string
+}
+
+export let makeStyles = ({
+  minItemWidth = "200px"
+}: GridStyleProps) => {
+  return {
+    container: css`
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(${minItemWidth}, 1fr));
+      gap: 30px;
+    `,
+    item: css`
+      width: 100%;
+      cursor: pointer;
+    `,
+  }
+}

--- a/packages/components/src/components/Grid/Grid.tsx
+++ b/packages/components/src/components/Grid/Grid.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { makeStyles, GridStyleProps } from "./Grid.style"
+
+type SectionProps = {
+  items?: React.ReactNode[]
+  className?: string
+} & GridStyleProps
+
+export default function Grid({
+  items = [],
+  className = "",
+  ...styleProps
+}: SectionProps) {
+  let styles = makeStyles(styleProps)
+  return (
+    <div css={styles.container} className={className}>
+      {items.map(item => <div css={styles.item}>{item}</div>)}
+    </div>
+  )
+}

--- a/packages/components/src/components/Grid/index.ts
+++ b/packages/components/src/components/Grid/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Grid";

--- a/packages/components/src/components/VideoPreview/VideoPreview.styles.tsx
+++ b/packages/components/src/components/VideoPreview/VideoPreview.styles.tsx
@@ -1,28 +1,22 @@
-import { css } from "@emotion/core";
-import { spacing, typography, colors } from "../../theme";
+import { css } from "@emotion/core"
+import { spacing, typography } from "./../../theme"
 
 export type VideoPreviewStyleProps = {
-  poster?: string;
-};
+  poster?: string
+}
 
 export let makeStyles = ({ poster }: VideoPreviewStyleProps) => {
-  let px210 = `${parseInt(spacing.s25) * 2.1}rem`;
-  let px120 = `${parseInt(spacing.s25) * 1.2}rem`;
   return {
     container: css`
-      padding-bottom: ${spacing.s4};
-      padding-right: ${spacing.s4};
+    `,
+    coverContainer: css`
+      width: 100%;
+      background-color: black;
     `,
     cover: css`
-      background-image: ${poster
-        ? `url(${poster})`
-        : `radial-gradient(${colors.bg.primary}, ${colors.bg.primary})`};
-      background-size: cover;
-      background-position: center;
-      min-width: ${px210};
-      min-height: ${px120};
-      max-width: ${px210};
-      max-height: ${px120};
+      display: block;
+      width: 100%;
+      height: auto;
     `,
     title: css`
       margin: ${spacing.s2} 0;
@@ -35,5 +29,5 @@ export let makeStyles = ({ poster }: VideoPreviewStyleProps) => {
     channelTitle: css`
       margin: ${spacing.s2} 0;
     `,
-  };
-};
+  }
+}

--- a/packages/components/src/components/VideoPreview/VideoPreview.tsx
+++ b/packages/components/src/components/VideoPreview/VideoPreview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { makeStyles, VideoPreviewStyleProps } from "./VideoPreview.styles";
-import Avatar from "../Avatar";
+import Avatar from "./../Avatar";
 
 type VideoPreviewProps = {
   url: string;
@@ -19,13 +19,16 @@ export default function VideoPreview({
   channelUrl,
   channelImg,
   showChannel = false,
+  poster,
   ...styleProps
 }: VideoPreviewProps) {
   let styles = makeStyles(styleProps);
   return (
     <div css={styles.container}>
       <a href={url}>
-        <div css={styles.cover}></div>
+        <div css={styles.coverContainer}>
+          <img css={styles.cover} src={poster} />
+        </div>
       </a>
       <div>
         <a href={url}>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,16 +1,11 @@
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { fas } from "@fortawesome/free-solid-svg-icons";
-
-library.add(fas);
-
-export { default as SearchBar } from "./components/SearchBar";
-export { default as Button } from "./components/Button";
-export { default as Video } from "./components/VideoPlayer";
 export { default as Avatar } from "./components/Avatar";
-export { default as GenericSection } from "./components/GenericSection";
-export { default as VideoPreview } from "./components/VideoPreview";
 export { default as Banner } from "./components/Banner";
+export { default as Button } from "./components/Button";
 export { default as ChannelSummary } from "./components/ChannelSummary";
-export { default as Label } from "./components/Label";
 export { default as DetailsTable } from "./components/DetailsTable";
+export { default as GenericSection } from "./components/GenericSection";
 export { default as Grid } from "./components/Grid";
+export { default as Label } from "./components/Label";
+export { default as SearchBar } from "./components/SearchBar";
+export { default as VideoPlayer } from "./components/VideoPlayer";
+export { default as VideoPreview } from "./components/VideoPreview";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -13,3 +13,4 @@ export { default as Banner } from "./components/Banner";
 export { default as ChannelSummary } from "./components/ChannelSummary";
 export { default as Label } from "./components/Label";
 export { default as DetailsTable } from "./components/DetailsTable";
+export { default as Grid } from "./components/Grid";

--- a/packages/components/stories/6-Grid.stories.tsx
+++ b/packages/components/stories/6-Grid.stories.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { Grid } from "./../src"
+
+export default {
+  title: "Grid",
+  component: Grid,
+}
+
+function Item() {
+  return (
+    <div>
+      <img src="https://27pc93zx53q14ywwgt4yq513-wpengine.netdna-ssl.com/wp-content/uploads/2016/08/video-placeholder-brain-bites.png" style={{ width: '100%' }} />
+      <p>Item title</p>
+    </div>
+  )
+}
+
+export const Default = () => <Grid items={([...Array(12).keys()].map(() => <Item />))} />
+
+export const WithMinItemWidth300 = () => <Grid minItemWidth="300px" items={([...Array(12).keys()].map(() => <Item />))} />
+
+export const WithClassName = () => <Grid className="customGrid" items={([...Array(12).keys()].map(() => <Item />))} />

--- a/packages/components/stories/6-Grid.stories.tsx
+++ b/packages/components/stories/6-Grid.stories.tsx
@@ -17,6 +17,6 @@ function Item() {
 
 export const Default = () => <Grid items={([...Array(12).keys()].map(() => <Item />))} />
 
-export const WithMinItemWidth300 = () => <Grid minItemWidth="300px" items={([...Array(12).keys()].map(() => <Item />))} />
+export const WithMinItemWidth300 = () => <Grid minItemWidth="300" items={([...Array(12).keys()].map(() => <Item />))} />
 
 export const WithClassName = () => <Grid className="customGrid" items={([...Array(12).keys()].map(() => <Item />))} />


### PR DESCRIPTION
This component allows to add components in a grid layout. It will be handy to show the videos in a more organised way and ready for mobile devices.

I've updated the VideoPreview component to work better with the Grid component. This way they stay as a grid layout and resize (width and height) according to the window width. 

![grid-component](https://user-images.githubusercontent.com/2123625/80003949-a62cee00-84b9-11ea-9203-0c1f92188303.gif)

There's only one caveat: if the video preview image has a different ratio, it will show with a different height.

From what I've seen there's no way to contain the image inside the div, unless we set it as its background. But **setting as the background requires to set the dimensions of the container**, and by doing that we lose the auto resize (width and height) that the grid layout gives us.

I wasn't able to find a solution where you don't have to set the item's width or height, unless we use JS and set them dynamically with the window resize, but that didn't seem like a good solution.

Maybe the video preview images could be cropped and resized to fit the a given ratio (maybe 16:9 since it's standard) on the backend (just wondering). There's some cloud services that do that type of transformations for us (e.g. Cloudinary).

If anyone knows how we could do the following using only CSS, and maintain the auto-resize feature from the grid layout, please let me know.

![Screenshot 2020-04-22 at 17 14 35](https://user-images.githubusercontent.com/2123625/80006468-d1fda300-84bc-11ea-804c-1fc10c529950.jpg)

Notice that on the first example (where the width of the image is larger than the container) it should have the same behaviour as _cover_, but for the second one it should do the same as _contain_.

If we take YouTube's example, they're transforming the cover image on the backend and making sure they're all the same ratio/size, AFAIK.